### PR TITLE
Fixed merge update 

### DIFF
--- a/lib/remocon/command/pull_command.rb
+++ b/lib/remocon/command/pull_command.rb
@@ -126,7 +126,7 @@ module Remocon
         removed = {}
 
         removed_keys.each do |k|
-          removed[k] = left[k]
+          removed[k] = Remocon::ParameterFileDumper.new({ k => left[k] }).dump
         end
 
         [unchanged, added, changed, removed]

--- a/lib/remocon/command/pull_command.rb
+++ b/lib/remocon/command/pull_command.rb
@@ -123,10 +123,8 @@ module Remocon
           end
         end
 
-        removed = {}
-
-        removed_keys.each do |k|
-          removed[k] = Remocon::ParameterFileDumper.new({ k => left[k] }).dump
+        removed = removed_keys.each_with_object({}) do |k, acc|
+          acc.merge!(Remocon::ParameterFileDumper.new({ k => left[k] }).dump)
         end
 
         [unchanged, added, changed, removed]

--- a/lib/remocon/command/pull_command.rb
+++ b/lib/remocon/command/pull_command.rb
@@ -113,7 +113,7 @@ module Remocon
         (right.keys & left.keys).each do |k|
           # both of left and right is config json's format
           # comparison should be done based on the format but dumped format should be returned
-          old =  left[k]
+          old = left[k]
           new = right[k]
 
           if old == new

--- a/lib/remocon/command/pull_command.rb
+++ b/lib/remocon/command/pull_command.rb
@@ -6,10 +6,11 @@ module Remocon
       class RemoteConfig
         include Remocon::InterpreterHelper
 
-        attr_reader :config
+        attr_reader :config, :cmd_opts
 
         def initialize(opts)
           @config = Remocon::Config.new(opts)
+          @cmd_opts = { validate_only: false }
         end
 
         def require_parameters_file_path
@@ -20,16 +21,15 @@ module Remocon
           config.conditions_file_path
         end
 
-        def raw_conditions
-          YAML.safe_load(File.open(require_conditions_file_path).read).map(&:with_indifferent_access)
+        def conditions_to_be_compared
+          JSON.parse(JSON.pretty_generate(condition_array.map { |c| c.skip_nil_values.stringify_values })).map(&:with_indifferent_access)
         end
 
-        def raw_parameters
-          YAML.safe_load(File.open(require_parameters_file_path).read).with_indifferent_access
+        def parameters_to_be_compared
+          JSON.parse(JSON.pretty_generate(parameter_hash.skip_nil_values.stringify_values)).with_indifferent_access
         end
       end
 
-      include Remocon::InterpreterHelper
       include Remocon::ConditionSorter
       include Remocon::ParameterSorter
 
@@ -39,14 +39,6 @@ module Remocon
         @config = Remocon::Config.new(opts)
         @cmd_opts = { validate_only: false }
         @left = RemoteConfig.new(opts)
-      end
-
-      def require_parameters_file_path
-        config.parameters_file_path
-      end
-
-      def require_conditions_file_path
-        config.conditions_file_path
       end
 
       def run
@@ -60,8 +52,8 @@ module Remocon
         parameters = raw_hash[:parameters] || {}
 
         if config.merge? && File.exist?(config.parameters_file_path) && File.exist?(config.parameters_file_path)
-          unchanged_conditions, added_conditions, changed_conditions, = conditions_diff(left.raw_conditions, conditions)
-          unchanged_parameters, added_parameters, changed_parameters, = parameters_diff(left.raw_parameters, parameters)
+          unchanged_conditions, added_conditions, changed_conditions, = conditions_diff(left.conditions_to_be_compared, conditions)
+          unchanged_parameters, added_parameters, changed_parameters, = parameters_diff(left.parameters_to_be_compared, parameters)
 
           conditions_yaml = JSON.parse(sort_conditions(unchanged_conditions + added_conditions + changed_conditions).to_json).to_yaml
           parameters_yaml = JSON.parse(sort_parameters(unchanged_parameters.merge(added_parameters).merge(changed_parameters)).to_json).to_yaml
@@ -89,12 +81,12 @@ module Remocon
 
         (right_names & left_names).each do |k|
           old = left.find { |c| c[:name] == k }
-          new = Remocon::ConditionFileDumper.new(right.find { |c| c[:name] == k }).dump
+          new = right.find { |c| c[:name] == k }
 
           if old == new
             unchanged.push(old)
           else
-            changed.push(new)
+            changed.push(Remocon::ConditionFileDumper.new(new).dump)
           end
         end
 
@@ -119,13 +111,15 @@ module Remocon
         unchanged = {}
 
         (right.keys & left.keys).each do |k|
-          old = { k => left[k] }
-          new = Remocon::ParameterFileDumper.new({ k => right[k] }).dump
+          # both of left and right is config json's format
+          # comparison should be done based on the format but dumped format should be returned
+          old =  left[k]
+          new = right[k]
 
           if old == new
-            unchanged.merge!(old)
+            unchanged.merge!(Remocon::ParameterFileDumper.new({ k => old }).dump)
           else
-            changed.merge!(new)
+            changed.merge!(Remocon::ParameterFileDumper.new({ k => new }).dump)
           end
         end
 

--- a/lib/remocon/normalizer/boolean_normalizer.rb
+++ b/lib/remocon/normalizer/boolean_normalizer.rb
@@ -7,8 +7,6 @@ module Remocon
     end
 
     def validate
-      return if [FalseClass, TrueClass].include?(@content.class)
-
       begin
         @bool_val = @content.to_s.to_boolean
       rescue ArgumentError => e

--- a/lib/remocon/normalizer/boolean_normalizer.rb
+++ b/lib/remocon/normalizer/boolean_normalizer.rb
@@ -7,11 +7,9 @@ module Remocon
     end
 
     def validate
-      begin
-        @bool_val = @content.to_s.to_boolean
-      rescue ArgumentError => e
-        raise ValidationError, e.message
-      end
+      @bool_val = @content.to_s.to_boolean
+    rescue ArgumentError => e
+      raise ValidationError, e.message
     end
 
     def normalize

--- a/lib/remocon/util/hash.rb
+++ b/lib/remocon/util/hash.rb
@@ -3,7 +3,7 @@
 class Hash
   def skip_nil_values
     dup.compact.each_with_object({}) do |(k, v), acc|
-      next unless v
+      next if v.nil?
       acc[k] = case v
                when Hash
                  v.skip_nil_values

--- a/spec/fixture/pull/new_config.json
+++ b/spec/fixture/pull/new_config.json
@@ -44,6 +44,16 @@
       "defaultValue": {
         "value": "1230947"
       }
+    },
+    "unchanged_normalizer_parameter": {
+      "defaultValue": {
+        "value": "123"
+      }
+    },
+    "changed_normalizer_parameter": {
+      "defaultValue": {
+        "value": "true"
+      }
     }
   }
 }

--- a/spec/fixture/pull/parameters.yml
+++ b/spec/fixture/pull/parameters.yml
@@ -15,3 +15,9 @@ unchanged_parameter:
       value: '300'
 will_be_removed_parameter:
   value: '123'
+unchanged_normalizer_parameter:
+  value: 123
+  normalizer: integer
+changed_normalizer_parameter:
+  value: false
+  normalizer: boolean

--- a/spec/remocon/command/pull_command_spec.rb
+++ b/spec/remocon/command/pull_command_spec.rb
@@ -215,7 +215,6 @@ module Remocon
         end
 
         it "should calculate removed diffs" do
-          # un-dump has not implemented yet so the returned format is from yaml files
           _, _, _, removed = command.parameters_diff(local_configs.parameters_to_be_compared, new_config_json[:parameters])
 
           expect(local_configs.parameters_to_be_compared.keys).to include("will_be_removed_parameter")
@@ -223,9 +222,7 @@ module Remocon
           expect(removed.size).to eq(1)
           expect(removed).to include(
             "will_be_removed_parameter" => {
-                "defaultValue" => {
-                    "value" => "123",
-                },
+                "value" => "123",
             }
           )
         end

--- a/spec/remocon/command/pull_command_spec.rb
+++ b/spec/remocon/command/pull_command_spec.rb
@@ -77,9 +77,9 @@ module Remocon
         it "should calculate diffs" do
           unchanged, added, changed, removed = command.parameters_diff(local_configs.raw_parameters, new_config_json[:parameters])
 
-          expect(unchanged.size).to eq(1)
+          expect(unchanged.size).to eq(2)
           expect(added.size).to eq(1)
-          expect(changed.size).to eq(1)
+          expect(changed.size).to eq(2)
           expect(removed.size).to eq(1)
         end
 
@@ -91,15 +91,18 @@ module Remocon
           expect(unchanged.size).to eq(1)
           expect(unchanged).to include(
             "unchanged_parameter" => {
-            "value" => "100",
-            "conditions" => {
-                "unchanged_condition" => {
-                    "value" => "100"
-                },
-                "changed_condition" => {
-                    "value" => "300"
+                "value" => "100",
+                "conditions" => {
+                    "unchanged_condition" => {
+                        "value" => "100"
+                    },
+                    "changed_condition" => {
+                        "value" => "300"
+                    }
                 }
-            }
+            },
+            "unchanged_normalizer_parameter" => {
+                "value" => "123"
             }
           )
         end
@@ -132,7 +135,10 @@ module Remocon
                       "value" => "200"
                   }
               }
-          }
+            },
+            "changed_normalizer_parameter" => {
+                "value" => "true"
+            }
           )
         end
 

--- a/spec/remocon/command/pull_command_spec.rb
+++ b/spec/remocon/command/pull_command_spec.rb
@@ -13,72 +13,72 @@ module Remocon
       describe Pull::RemoteConfig do
         it "#conditions_to_be_compared" do
           expect(local_configs.conditions_to_be_compared).to eq(
-                                                                 [
-                                                                     {
-                                                                         "name" => "unchanged_condition",
-                                                                         "expression" => "device.os == 'ios'",
-                                                                         "tagColor" => "INDIGO",
-                                                                     },
-                                                                     {
-                                                                         "name" => "changed_condition",
-                                                                         "expression" => "device.os == 'android'",
-                                                                         "tagColor" => "CYAN",
-                                                                     },
-                                                                     {
-                                                                         "name" => "will_be_removed_condition",
-                                                                         "expression" => "device.os == 'ios'",
-                                                                         "tagColor" => "CYAN",
-                                                                     },
-                                                                 ]
-                                                             )
+            [
+              {
+                    "name" => "unchanged_condition",
+                    "expression" => "device.os == 'ios'",
+                    "tagColor" => "INDIGO",
+                },
+              {
+                  "name" => "changed_condition",
+                  "expression" => "device.os == 'android'",
+                  "tagColor" => "CYAN",
+              },
+              {
+                  "name" => "will_be_removed_condition",
+                  "expression" => "device.os == 'ios'",
+                  "tagColor" => "CYAN",
+              },
+            ]
+          )
         end
 
         it "#parameters_to_be_compared" do
           expect(local_configs.parameters_to_be_compared).to eq(
-                                                                   {
-                                                                       "changed_parameter" => {
-                                                                           "defaultValue" => {
-                                                                               "value" => "100"
-                                                                           },
-                                                                           "conditionalValues" => {
-                                                                               "unchanged_condition" => {
-                                                                                   "value" => "200"
-                                                                               },
-                                                                               "will_be_removed_condition" => {
-                                                                                   "value" => "100"
-                                                                               }
-                                                                           }
-                                                                       },
-                                                                       "unchanged_parameter" => {
-                                                                           "defaultValue" => {
-                                                                               "value" => "100"
-                                                                           },
-                                                                           "conditionalValues" => {
-                                                                               "unchanged_condition" => {
-                                                                                   "value" => "100"
-                                                                               },
-                                                                               "changed_condition" => {
-                                                                                   "value" => "300"
-                                                                               },
-                                                                           }
-                                                                       },
-                                                                       "will_be_removed_parameter" => {
-                                                                           "defaultValue" => {
-                                                                               "value" => "123"
-                                                                           }
-                                                                       },
-                                                                       "unchanged_normalizer_parameter" => {
-                                                                           "defaultValue" => {
-                                                                               "value" => "123"
-                                                                           }
-                                                                       },
-                                                                       "changed_normalizer_parameter" => {
-                                                                           "defaultValue" => {
-                                                                               "value" => "false"
-                                                                           }
-                                                                       },
-                                                                   }
-                                                             )
+            {
+                "changed_parameter" => {
+                    "defaultValue" => {
+                        "value" => "100"
+                    },
+                    "conditionalValues" => {
+                        "unchanged_condition" => {
+                            "value" => "200"
+                        },
+                        "will_be_removed_condition" => {
+                            "value" => "100"
+                        }
+                    }
+                },
+                "unchanged_parameter" => {
+                    "defaultValue" => {
+                        "value" => "100"
+                    },
+                    "conditionalValues" => {
+                        "unchanged_condition" => {
+                            "value" => "100"
+                        },
+                        "changed_condition" => {
+                            "value" => "300"
+                        },
+                    }
+                },
+                "will_be_removed_parameter" => {
+                    "defaultValue" => {
+                        "value" => "123"
+                    }
+                },
+                "unchanged_normalizer_parameter" => {
+                    "defaultValue" => {
+                        "value" => "123"
+                    }
+                },
+                "changed_normalizer_parameter" => {
+                    "defaultValue" => {
+                        "value" => "false"
+                    }
+                },
+            }
+          )
         end
       end
 

--- a/spec/remocon/command/pull_command_spec.rb
+++ b/spec/remocon/command/pull_command_spec.rb
@@ -10,9 +10,81 @@ module Remocon
       let(:local_configs) { Pull::RemoteConfig.new(opts) }
       let(:new_config_json) { JSON.parse(File.open(fixture_path("pull/new_config.json")).read).with_indifferent_access }
 
+      describe Pull::RemoteConfig do
+        it "#conditions_to_be_compared" do
+          expect(local_configs.conditions_to_be_compared).to eq(
+                                                                 [
+                                                                     {
+                                                                         "name" => "unchanged_condition",
+                                                                         "expression" => "device.os == 'ios'",
+                                                                         "tagColor" => "INDIGO",
+                                                                     },
+                                                                     {
+                                                                         "name" => "changed_condition",
+                                                                         "expression" => "device.os == 'android'",
+                                                                         "tagColor" => "CYAN",
+                                                                     },
+                                                                     {
+                                                                         "name" => "will_be_removed_condition",
+                                                                         "expression" => "device.os == 'ios'",
+                                                                         "tagColor" => "CYAN",
+                                                                     },
+                                                                 ]
+                                                             )
+        end
+
+        it "#parameters_to_be_compared" do
+          expect(local_configs.parameters_to_be_compared).to eq(
+                                                                   {
+                                                                       "changed_parameter" => {
+                                                                           "defaultValue" => {
+                                                                               "value" => "100"
+                                                                           },
+                                                                           "conditionalValues" => {
+                                                                               "unchanged_condition" => {
+                                                                                   "value" => "200"
+                                                                               },
+                                                                               "will_be_removed_condition" => {
+                                                                                   "value" => "100"
+                                                                               }
+                                                                           }
+                                                                       },
+                                                                       "unchanged_parameter" => {
+                                                                           "defaultValue" => {
+                                                                               "value" => "100"
+                                                                           },
+                                                                           "conditionalValues" => {
+                                                                               "unchanged_condition" => {
+                                                                                   "value" => "100"
+                                                                               },
+                                                                               "changed_condition" => {
+                                                                                   "value" => "300"
+                                                                               },
+                                                                           }
+                                                                       },
+                                                                       "will_be_removed_parameter" => {
+                                                                           "defaultValue" => {
+                                                                               "value" => "123"
+                                                                           }
+                                                                       },
+                                                                       "unchanged_normalizer_parameter" => {
+                                                                           "defaultValue" => {
+                                                                               "value" => "123"
+                                                                           }
+                                                                       },
+                                                                       "changed_normalizer_parameter" => {
+                                                                           "defaultValue" => {
+                                                                               "value" => "false"
+                                                                           }
+                                                                       },
+                                                                   }
+                                                             )
+        end
+      end
+
       context "#conditions_diff" do
         it "should calculate diffs" do
-          unchanged, added, changed, removed = command.conditions_diff(local_configs.raw_conditions, new_config_json[:conditions])
+          unchanged, added, changed, removed = command.conditions_diff(local_configs.conditions_to_be_compared, new_config_json[:conditions])
 
           expect(unchanged.size).to eq(1)
           expect(added.size).to eq(1)
@@ -21,9 +93,9 @@ module Remocon
         end
 
         it "should calculate unchanged diffs" do
-          unchanged, = command.conditions_diff(local_configs.raw_conditions, new_config_json[:conditions])
+          unchanged, = command.conditions_diff(local_configs.conditions_to_be_compared, new_config_json[:conditions])
 
-          expect(local_configs.raw_conditions.any? { |c| c[:name] == "unchanged_condition" }).to be_truthy
+          expect(local_configs.conditions_to_be_compared.any? { |c| c[:name] == "unchanged_condition" }).to be_truthy
           expect(new_config_json[:conditions].any? { |c| c[:name] == "unchanged_condition" }).to be_truthy
           expect(unchanged.size).to eq(1)
           expect(unchanged.first).to include(
@@ -34,9 +106,9 @@ module Remocon
         end
 
         it "should calculate added diffs" do
-          _, added, = command.conditions_diff(local_configs.raw_conditions, new_config_json[:conditions])
+          _, added, = command.conditions_diff(local_configs.conditions_to_be_compared, new_config_json[:conditions])
 
-          expect(local_configs.raw_conditions.any? { |c| c[:name] == "added_condition" }).to be_falsey
+          expect(local_configs.conditions_to_be_compared.any? { |c| c[:name] == "added_condition" }).to be_falsey
           expect(new_config_json[:conditions].any? { |c| c[:name] == "added_condition" }).to be_truthy
           expect(added.size).to eq(1)
           expect(added.first).to include(
@@ -47,9 +119,9 @@ module Remocon
         end
 
         it "should calculate changed diffs" do
-          _, _, changed, = command.conditions_diff(local_configs.raw_conditions, new_config_json[:conditions])
+          _, _, changed, = command.conditions_diff(local_configs.conditions_to_be_compared, new_config_json[:conditions])
 
-          expect(local_configs.raw_conditions.any? { |c| c[:name] == "changed_condition" }).to be_truthy
+          expect(local_configs.conditions_to_be_compared.any? { |c| c[:name] == "changed_condition" }).to be_truthy
           expect(new_config_json[:conditions].any? { |c| c[:name] == "changed_condition" }).to be_truthy
           expect(changed.size).to eq(1)
           expect(changed.first).to include(
@@ -60,9 +132,9 @@ module Remocon
         end
 
         it "should calculate removed diffs" do
-          _, _, _, removed = command.conditions_diff(local_configs.raw_conditions, new_config_json[:conditions])
+          _, _, _, removed = command.conditions_diff(local_configs.conditions_to_be_compared, new_config_json[:conditions])
 
-          expect(local_configs.raw_conditions.any? { |c| c[:name] == "will_be_removed_condition" }).to be_truthy
+          expect(local_configs.conditions_to_be_compared.any? { |c| c[:name] == "will_be_removed_condition" }).to be_truthy
           expect(new_config_json[:conditions].any? { |c| c[:name] == "will_be_removed_condition" }).to be_falsey
           expect(removed.size).to eq(1)
           expect(removed.first).to include(
@@ -75,7 +147,7 @@ module Remocon
 
       context "#parameters_diff" do
         it "should calculate diffs" do
-          unchanged, added, changed, removed = command.parameters_diff(local_configs.raw_parameters, new_config_json[:parameters])
+          unchanged, added, changed, removed = command.parameters_diff(local_configs.parameters_to_be_compared, new_config_json[:parameters])
 
           expect(unchanged.size).to eq(2)
           expect(added.size).to eq(1)
@@ -84,11 +156,11 @@ module Remocon
         end
 
         it "should calculate unchanged diffs" do
-          unchanged, = command.parameters_diff(local_configs.raw_parameters, new_config_json[:parameters])
+          unchanged, = command.parameters_diff(local_configs.parameters_to_be_compared, new_config_json[:parameters])
 
-          expect(local_configs.raw_parameters.keys).to include("unchanged_parameter")
+          expect(local_configs.parameters_to_be_compared.keys).to include("unchanged_parameter")
           expect(new_config_json[:parameters].keys).to include("unchanged_parameter")
-          expect(unchanged.size).to eq(1)
+          expect(unchanged.size).to eq(2)
           expect(unchanged).to include(
             "unchanged_parameter" => {
                 "value" => "100",
@@ -108,9 +180,9 @@ module Remocon
         end
 
         it "should calculate added diffs" do
-          _, added, = command.parameters_diff(local_configs.raw_parameters, new_config_json[:parameters])
+          _, added, = command.parameters_diff(local_configs.parameters_to_be_compared, new_config_json[:parameters])
 
-          expect(local_configs.raw_parameters.keys).not_to include("added_parameter")
+          expect(local_configs.parameters_to_be_compared.keys).not_to include("added_parameter")
           expect(new_config_json[:parameters].keys).to include("added_parameter")
           expect(added.size).to eq(1)
           expect(added).to include(
@@ -121,11 +193,11 @@ module Remocon
         end
 
         it "should calculate changed diffs" do
-          _, _, changed, = command.parameters_diff(local_configs.raw_parameters, new_config_json[:parameters])
+          _, _, changed, = command.parameters_diff(local_configs.parameters_to_be_compared, new_config_json[:parameters])
 
-          expect(local_configs.raw_parameters.keys).to include("changed_parameter")
+          expect(local_configs.parameters_to_be_compared.keys).to include("changed_parameter")
           expect(new_config_json[:parameters].keys).to include("changed_parameter")
-          expect(changed.size).to eq(1)
+          expect(changed.size).to eq(2)
 
           expect(changed).to include(
             "changed_parameter" => {
@@ -143,14 +215,17 @@ module Remocon
         end
 
         it "should calculate removed diffs" do
-          _, _, _, removed = command.parameters_diff(local_configs.raw_parameters, new_config_json[:parameters])
+          # un-dump has not implemented yet so the returned format is from yaml files
+          _, _, _, removed = command.parameters_diff(local_configs.parameters_to_be_compared, new_config_json[:parameters])
 
-          expect(local_configs.raw_parameters.keys).to include("will_be_removed_parameter")
+          expect(local_configs.parameters_to_be_compared.keys).to include("will_be_removed_parameter")
           expect(new_config_json[:parameters].keys).not_to include("will_be_removed_parameter")
           expect(removed.size).to eq(1)
           expect(removed).to include(
             "will_be_removed_parameter" => {
-                "value" => "123",
+                "defaultValue" => {
+                    "value" => "123",
+                },
             }
           )
         end


### PR DESCRIPTION
The previous merge update checks YAML's format but the values are not evaluated.
So *diff calculation* works wrong when `file`, `normalizer` etc. are included.