### PR TITLE
Updates for Firebase Remote Config

### DIFF
--- a/lib/remocon/command/lib/request.rb
+++ b/lib/remocon/command/lib/request.rb
@@ -53,11 +53,19 @@ module Remocon
     end
 
     def self.pull(config)
-      raw_json, etag = open(config.endpoint, "Authorization" => "Bearer #{config.token}") do |io|
-        [io.read, io.meta["etag"]]
-      end
+      client, uri = Request.build_client(config)
 
-      [raw_json, etag]
+      headers = {
+          "Authorization" => "Bearer #{config.token}",
+          "Content-Type" => "application/json; UTF8",
+          "Content-Encoding" => "gzip",
+      }
+
+      request = Net::HTTP::Get.new(uri.request_uri, headers)
+
+      response = client.request(request)
+
+      [response.body, response.header["etag"]]
     end
 
     def self.fetch_etag(config)
@@ -68,10 +76,11 @@ module Remocon
       headers = {
           "Authorization" => "Bearer #{config.token}",
           "Content-Type" => "application/json; UTF8",
-          "Content-Encoding" => "gzip",
+          "Content-Encoding" => "gzip"
       }
 
       request = Net::HTTP::Get.new(uri.request_uri, headers)
+
       response = client.request(request)
 
       response.kind_of?(Net::HTTPOK) && response.header["etag"]

--- a/lib/remocon/dumper/parameter_file_dumper.rb
+++ b/lib/remocon/dumper/parameter_file_dumper.rb
@@ -8,6 +8,8 @@ module Remocon
 
     def dump
       @parameters.each_with_object({}) do |(key, body), hash|
+        next unless body[:defaultValue][:value]
+
         hash[key] = body[:defaultValue]
         hash[key][:description] = body[:description] if body[:description]
 

--- a/lib/remocon/version.rb
+++ b/lib/remocon/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Remocon
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
Some changes needed due to firebase remote config updates:

-- required headers in "get remote config" to avoid 404 entity not found errors

-- ignore parameters that don't have a default value (are using in-app defaults)